### PR TITLE
Spatial cv

### DIFF
--- a/calibrain/cross_val.py
+++ b/calibrain/cross_val.py
@@ -1,0 +1,142 @@
+
+import numpy as np
+from sklearn.model_selection import GridSearchCV
+from sklearn.base import BaseEstimator, ClassifierMixin, clone
+from sklearn.model_selection import check_cv
+
+
+from .estimators import SpatialSolver
+
+
+def _logdet(A):
+    """Compute the logdet of a positive semidefinite matrix."""
+    from scipy import linalg
+
+    vals = linalg.eigvalsh(A)
+    # avoid negative (numerical errors) or zero (semi-definite matrix) values
+    tol = vals.max() * vals.size * np.finfo(np.float64).eps
+    vals = np.where(vals > tol, vals, tol)
+    return np.sum(np.log(vals))
+
+
+def logdet_bregman_div_distance_nll(y, Sigma_Y):
+    """Compute the log-det Bregman divergence between two matrices."""
+    Sigma_Y_inv = np.linalg.inv(Sigma_Y)
+    n_features, n_times = y.shape
+    Cov_y = y @ y.T / n_times
+    log_like = np.mean(np.sum((y.T @ Sigma_Y_inv) * y.T, axis=1))
+    log_like -= _logdet(Cov_y @ Sigma_Y_inv)
+    out = log_like - n_features
+    return out
+
+
+DEFAULT_ALPHA_GRID = np.logspace(0, -2, 20)[1:]
+
+
+class BaseCVSolver(BaseEstimator, ClassifierMixin):
+    def __init__(
+        self,
+        solver,
+        cov_type,
+        cov,
+        n_orient,
+        alphas=DEFAULT_ALPHA_GRID,
+        cv=5,
+        extra_params={},
+        n_jobs=1,
+    ):
+        self.solver = solver
+        self.alphas = alphas
+        self.cov = cov
+        self.cov_type = cov_type
+        self.n_orient = n_orient
+        self.cv = cv
+        self.extra_params = extra_params
+        self.n_jobs = n_jobs
+        self.alpha_ = None
+
+    def fit(self, L, y):
+        self.L_ = L
+        self.y_ = y
+
+        return self
+
+    def predict(self, y):
+        self._get_alpha(y)
+
+        if self.cov_type == "diag":
+            self.coef_ = self.solver(
+                self.L_,
+                y,
+                alpha=self.alpha_,
+                n_orient=self.n_orient,
+                **self.extra_params
+            )
+        else:
+            self.coef_ = self.solver(
+                self.L_,
+                y,
+                self.cov,
+                alpha=self.alpha_,
+                n_orient=self.n_orient,
+                **self.extra_params
+            )
+
+        return self.coef_
+
+
+class SpatialCVSolver(BaseCVSolver):
+    def _get_alpha(self, y):
+        """Sets alpha_ attribute with spatial cross-validation."""
+        gs = GridSearchCV(
+            estimator=SpatialSolver(
+                self.solver,
+                cov=self.cov,
+                alpha=None,
+                cov_type=self.cov_type,
+                n_orient=self.n_orient,
+            ),
+            param_grid=dict(alpha=self.alphas),
+            scoring="neg_mean_squared_error",
+            cv=self.cv,
+            n_jobs=self.n_jobs,
+            error_score="raise",
+        )
+        gs.fit(self.L_, y)
+        self.grid_search_ = gs
+        self.alpha_ = gs.best_estimator_.alpha
+
+
+class TemporalCVSolver(BaseCVSolver):
+    def _get_alpha(self, y):
+        """Sets alpha_ attribute with temporal cross-validation."""
+        base_solver = SpatialSolver(
+            self.solver,
+            cov=self.cov,
+            alpha=None,
+            cov_type=self.cov_type,
+            n_orient=self.n_orient,
+        )
+
+        cv = check_cv(self.cv)
+        scores = []
+        for alpha in self.alphas:
+            solver = clone(base_solver)
+            solver.set_params(alpha=alpha)
+            temporal_cv_scores = []
+            for train_idx, test_idx in cv.split(y.T):
+                solver.fit(self.L_, y[:, train_idx])
+                y_test = y[:, test_idx]
+
+                # X_Sqaure = solver.coef_ @ solver.coef_.T
+                # Cov_X = np.diag(np.linalg.norm(X_Sqaure, axis=0))
+                # Sigma_Y = self.cov + ((self.L_ @ Cov_X) @ self.L_.T)
+
+                X_var = np.mean(solver.coef_ ** 2, axis=1)  # already zero mean
+                Sigma_Y = self.cov + ((self.L_ * X_var[None, :]) @ self.L_.T)
+
+                temporal_cv_scores.append(
+                    logdet_bregman_div_distance_nll(y_test, Sigma_Y)
+                )
+            scores.append(np.mean(temporal_cv_scores))
+        self.alpha_ = self.alphas[np.argmax((scores))]

--- a/calibrain/vbfa.py
+++ b/calibrain/vbfa.py
@@ -70,27 +70,39 @@ class VBFA:
                 self._plot(i)
 
         # Final outputs
-        self.weight = self.b @ igam @ self.b.T @ np.diag(self.lam)
+        self.weight = (self.b @ igam @ self.b.T @ 
+                      np.diag(self.lam))
         self.sig = self.b @ self.b.T + np.diag(1.0 / self.lam)
         self.yc = self.b @ ubar
-        self.cy = self.b @ ruu @ self.b.T + np.diag(np.diag(self.sig) * np.trace(ruu @ inv(ruu + np.diag(self.bet))))
+        self.cy = (self.b @ ruu @ self.b.T + 
+                  np.diag(np.diag(self.sig) * 
+                         np.trace(ruu @ inv(ruu + np.diag(self.bet)))))
         self.mlike = self.likelihood[-1]
 
     def _compute_gamma(self, rbb: np.ndarray) -> np.ndarray:
         dlam = np.diag(self.lam)
-        return self.b.T @ dlam @ self.b + np.eye(self.nl) + self.b.shape[0] * rbb
+        return (self.b.T @ dlam @ self.b + 
+                np.eye(self.nl) + 
+                self.b.shape[0] * rbb)
 
-    def _compute_likelihood(self, y: np.ndarray, ryu: np.ndarray, ruu: np.ndarray, gam: np.ndarray) -> float:
+    def _compute_likelihood(self, y: np.ndarray, ryu: np.ndarray, 
+                          ruu: np.ndarray, gam: np.ndarray) -> float:
         nk, nt = y.shape
         _, d, _ = svd(gam)
         ldgam = np.sum(np.log(d))
-        temp1 = -0.5 * ldgam + 0.5 * np.sum(np.sum(ubar * (gam @ ubar), axis=0)) / nt
-        temp2 = 0.5 * np.sum(np.log(self.lam)) - 0.5 * (self.lam @ np.mean(y**2, axis=1))
-        f3 = 0.5 * self.nl * np.sum(np.log(self.lam)) + 0.5 * nk * np.sum(np.log(self.bet)) - 0.5 * np.trace(self.b.T @ np.diag(self.lam) @ self.b @ np.diag(self.bet))
+        temp1 = (-0.5 * ldgam + 
+                0.5 * np.sum(np.sum(ubar * (gam @ ubar), axis=0)) / nt)
+        temp2 = (0.5 * np.sum(np.log(self.lam)) - 
+                0.5 * (self.lam @ np.mean(y**2, axis=1)))
+        f3 = (0.5 * self.nl * np.sum(np.log(self.lam)) + 
+              0.5 * nk * np.sum(np.log(self.bet)) - 
+              0.5 * np.trace(self.b.T @ np.diag(self.lam) @ 
+                            self.b @ np.diag(self.bet)))
         return temp1 + temp2 + f3 / nt
 
     def _update_bet(self, ruu: np.ndarray) -> np.ndarray:
-        return 1.0 / (np.diag(self.b.T @ np.diag(self.lam) @ self.b) / self.b.shape[0] + np.diag(inv(ruu)))
+        return 1.0 / (np.diag(self.b.T @ np.diag(self.lam) @ self.b) / 
+                     self.b.shape[0] + np.diag(inv(ruu)))
 
     def _update_b(self, ryu: np.ndarray, ruu: np.ndarray) -> np.ndarray:
         return ryu @ inv(ruu + np.diag(self.bet))
@@ -104,7 +116,10 @@ class VBFA:
         fig, axes = plt.subplots(3, 3, figsize=(10, 8))
         axes[0, 0].plot(self.likelihood[: i+1])
         axes[0, 0].set_title('Likelihood')
-        axes[1, 0].plot(np.sqrt(np.vstack([np.mean(self.b**2, axis=0), 1.0 / self.bet]).T))
+        axes[1, 0].plot(np.sqrt(np.vstack([
+            np.mean(self.b**2, axis=0), 
+            1.0 / self.bet
+        ]).T))
         axes[1, 0].set_title('1/bet')
         axes[2, 0].plot(1.0 / self.lam)
         axes[2, 0].set_title('1/lam')


### PR DESCRIPTION
# Pull Request: Add Temporal and Spatial Cross-Validation Solvers

## Summary

This PR introduces two cross-validation strategies to select the optimal regularization parameter $\alpha$ (i.e., noise level $\lambda$) for Champagne and LowSNR-BSI models:

- **TemporalCVSolver** implements $k$-fold **temporal cross-validation** based on the **Type-II log-likelihood**, evaluated via **log-det Bregman divergence**.
- **SpatialCVSolver** implements **spatial cross-validation** based on the **Type-I log-likelihood**, evaluated as the mean squared error (MSE) on held-out sensors.

Both solvers inherit from a shared `BaseCVSolver` class, follow scikit-learn conventions, and support parallel grid search over a configurable range of $\alpha$ values.

---

## Background

### Temporal Cross-Validation

In temporal CV, the data $\mathbf{Y} \in \mathbb{R}^{M \times T}$ are split into $k$ contiguous temporal folds. For each split, the model is trained on $k-1$ folds and evaluated on the remaining fold using the **out-of-sample Type-II log-likelihood**:
 
 
$$
\mathcal{L}^{\text{II}}(\mathbf{Y}^{\text{train}}, \mathbf{Y}^{\text{test}}) =
\mathrm{tr}(\mathbf{C}_{\mathbf{y}^{\text{test}}} \boldsymbol{\Sigma}_{\mathbf{y}^{\text{train}}}^{-1}) +
\log|\boldsymbol{\Sigma}_{\mathbf{y}^{\text{train}}}|
$$

Here:
- $\mathbf{C}_{\mathbf{y}^{\text{test}}}$ is the empirical covariance of the test data
- $\boldsymbol{\Sigma}_{\mathbf{y}^{\text{train}}}$ is the model covariance estimated from the training set

This quantity corresponds to the **log-det Bregman divergence** and is theoretically justified as a second-order comparison between model and empirical covariances.

---

### Spatial Cross-Validation

In spatial CV, the sensor space is split into training and test sets. The model is trained on a subset of sensors and the predicted source activity $\mathbf{X}^{\text{train}}$ is mapped back to the test sensors using the corresponding lead field matrix. The **Type-I log-likelihood** is then computed as:

$$
\mathcal{L}^{\text{I}}(\mathbf{Y}^{\text{test}}, \mathbf{L}^{\text{test}}, \mathbf{X}^{\text{train}}) =
\left\Vert \mathbf{Y}^{\text{test}} - \mathbf{L}^{\text{test}} \mathbf{X}^{\text{train}} \right\Vert_F^2
$$

This metric corresponds to the **MSE** (first-order discrepancy) between observed and predicted data on the held-out sensors.

---

##  Implementation Highlights

- `BaseCVSolver` defines shared initialization, `fit`, and `predict` logic.
- `SpatialCVSolver` uses `GridSearchCV` with MSE scoring to select $\alpha$.
- `TemporalCVSolver` manually implements k-fold splitting and uses log-det Bregman divergence to select $\alpha$.
- Utility functions:
  - `_logdet()` — numerically stable log-determinant computation
  - `logdet_bregman_div_distance_nll()` — implements the divergence metric

---

## ✅ Example Usage

```python
solver = TemporalCVSolver(
    solver=some_solver_fn,
    cov_type='full',
    cov=estimated_noise_cov,
    n_orient=1,
    cv=4,
    alphas=np.logspace(0, -3, 10)
)
solver.fit(leadfield, Y)
X_hat = solver.predict(Y)
