### PR TITLE
Add Alpha-SNR-Based Noise Model for Sensor Signal Simulation

### DIFF
--- a/calibrain/benchmark.py
+++ b/calibrain/benchmark.py
@@ -60,7 +60,7 @@ class Benchmark:
         # Desired order of parameters for the directory structure
         # This list defines the specific order.
         if desired_order is None:
-            desired_order = ["subject", "solver", "gammas", "orientation_type", "nnz", "noise_type", "alpha_snr_db", "seed"]
+            desired_order = ["subject", "solver", "gammas", "orientation_type", "nnz", "noise_type", "alpha_SNR", "seed"]
         
         path_components = []
         
@@ -122,7 +122,7 @@ class Benchmark:
             experiment_dir = self.create_experiment_directory(
                 base_dir=fig_path,
                 params=this_result,
-                desired_order = ["subject", "solver", "gammas", "orientation_type", "nnz", "noise_type", "alpha_snr_db", "seed"]
+                desired_order = ["subject", "solver", "gammas", "orientation_type", "nnz", "noise_type", "alpha_SNR", "seed"]
             )
             
             self.data_simulator.__dict__.update(data_params)
@@ -137,7 +137,7 @@ class Benchmark:
                     visualize=True,
                     save_path=os.path.join(experiment_dir , "data_simulation")
                 )
-                y_noisy, L, x, x_active_indices, noise, noise_power = data
+                y_noisy, L, x, x_active_indices, noise, noise_var = data
                 trial_i = 0
                 
                 # if solver_params.get("noise_type") == 'oracle':
@@ -155,7 +155,7 @@ class Benchmark:
                 )            
                 source_estimator.fit(L, y_noisy)            
                 x_hat, x_hat_active_set, posterior_cov = source_estimator.predict(
-                    y=y_noisy[trial_i], noise_var=noise_power[trial_i]
+                    y=y_noisy[trial_i], noise_var=noise_var[trial_i]
                 )
                 this_result['active_set_size'] = len(x_hat_active_set)
                 

--- a/examples/run_experiments.py
+++ b/examples/run_experiments.py
@@ -8,7 +8,9 @@ from pathlib import Path
 from calibrain import DataSimulator, gamma_map, eloreta
 from calibrain import Benchmark
 
+# https://github.com/mne-tools/mne-python/blob/main/mne/_fiff/constants.py
 # print(fwd['info']['chs'][0]['unit'])  # Will show 107 (FIFF_UNIT_V)
+
 def main():
     os.makedirs("results/benchmark_results", exist_ok=True)
     timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -37,7 +39,7 @@ def main():
         sfreq=250,
         fmin=1,
         fmax=5,
-        amplitude=5,
+        amplitude=1,
         n_trials=4, # we will slice this to use only the first trial. TODO: Keep it like this for now
         leadfield_mode='load', # (simulate, random, load). NOTE: if `simulate` then align the config file of the leadfield simulation!
         channel_type='eeg',
@@ -66,16 +68,16 @@ def main():
         
     data_param_grid_meg = {
         "subject": ["CC120166", "fsaverage"], # "CC120166", "CC120264", "CC120309", "CC120313", "caliBrain_fsaverage", # "fsaverage", 
-        "nnz": [3, 5],
+        "nnz": [1, 5],
         "orientation_type": ["fixed"], # "fixed", "free"
-        "alpha_snr_db": [-40, 40],
+        "alpha_SNR": [0.0, 0.5, 1.0],
     }
     
     data_param_grid_eeg = {
         "subject": ["caliBrain_fsaverage"], # "CC120166", "CC120264", "CC120309", "CC120313", "caliBrain_fsaverage", # "fsaverage", 
-        "nnz": [3, 5],
+        "nnz": [1, 5],
         "orientation_type": ["fixed"], # "fixed", "free"
-        "alpha_snr_db": [-40, 40],
+        "alpha_SNR": [0.0, 0.5, 1.0],
     }
         
     gamma_map_params = {
@@ -98,7 +100,7 @@ def main():
     # "accuracy",  
     ]
     
-    nruns = 2
+    nruns = 1
     df = []
     for solver, solver_param_grid, data_param_grid, data_simulator in estimators:
         benchmark = Benchmark(


### PR DESCRIPTION
Closes #5 

Implemented an interpretable noise injection method based on the Alpha-SNR formulation. The approach allows to control signal-to-noise ratio (SNR) in a bounded and unitless manner during EEG/MEG simulation by specifying a single parameter: $\alpha \in (0, 1)$.

# Motivation

The traditional decibel-based SNR control using $\text{SNR}_{\text{dB}}$ can be unintuitive and difficult to interpret across varying signal strengths. The Alpha-SNR approach addresses this by defining noise level via the relative energy of the signal in the total signal-plus-noise mixture.

# Mathematical Formulation

Let:
- $\mathbf{Y}_{\text{signal}} \in \mathbb{R}^{M \times T}$: clean sensor signal
- $\boldsymbol{\varepsilon} \sim \mathcal{N}(0, \sigma_{\varepsilon}^2 \cdot \mathbf{I})$: i.i.d. zero-mean Gaussian noise with standard deviation $\sigma_{\varepsilon}$ (default is $\sigma_{\varepsilon} = 1.0$)
- $\eta \in \mathbb{R}+$: scaling factor applied to noise

We define signal and noise power:
- $P_{\text{signal}} := \frac{1}{MT} \| \mathbf{Y}_{\text{signal}} \|_F^2 \quad$ (signal power),
- $P_{\text{noise}} := \frac{1}{MT} \| \eta \cdot \boldsymbol{\varepsilon} \|_F^2$ (noise power)

The Alpha-SNR parameter $\alpha \in (0, 1)$ defines the signal proportion:
$\alpha := \frac{P_{\text{signal}}}{P_{\text{signal}} + P_{\text{noise}}} = \frac{1}{1 + \eta^2 / P_{\text{signal}}}$

Solving for $\eta$, we obtain:
$\eta = \left( \frac{1 - \alpha}{\alpha} \right) \cdot \frac{\| \mathbf{Y}_{\text{signal}} \|_F}{\| \boldsymbol{\varepsilon} \|_F}$

The final noisy signal is:
$\mathbf{Y}{\text{noisy}} = \mathbf{Y}{\text{signal}} + \eta \cdot \boldsymbol{\varepsilon}$

The noise variance per element is given by the variance of any entry $\varepsilon_{ij}^{\text{scaled}}$:

$\text{Var}[\eta \cdot \varepsilon_{ij}] = \eta^2 \cdot \text{Var}[\varepsilon_{ij}] = \eta^2$

Hence, the total noise variance (used in the simulation return value) is:

$\sigma^2 = \eta^2$


# Changes Introduced

- Implemented Alpha-SNR noise model in the `_add_noise()` method.
- The updated method now returns:
  - The noisy signal
  - The added (scaled) noise
  - The effective noise variance
- Modified files:
  - `data_simulation.py`
  - `benchmark.py`
  - `run_experiments.py`

# Usage

```Python
data_simulator =  DataSimulator(alpha_SNR=0.8)
data = data_simulator.simulate(
    subject='fsaverage', 
    seed=42
)
y_noisy, L, x, x_active_indices, noise, noise_var = data
```

# Notes
This PR only implements homoscedastic, white Gaussian noise.
